### PR TITLE
Fixed a typo that prevents using SOCKS 4/5 proxy

### DIFF
--- a/externals/reqresp/Request.py
+++ b/externals/reqresp/Request.py
@@ -306,9 +306,9 @@ class Request:
 	    proxy = req.getProxy()
 	    if proxy != None:
 		    c.setopt(pycurl.PROXY, proxy)
-		    if req.proxytype=="SOCK5":
+		    if req.proxytype=="SOCKS5":
 			    c.setopt(pycurl.PROXYTYPE,pycurl.PROXYTYPE_SOCKS5)
-		    elif req.proxytype=="SOCK4":
+		    elif req.proxytype=="SOCKS4":
 			    c.setopt(pycurl.PROXYTYPE,pycurl.PROXYTYPE_SOCKS4)
 		    req.delHeader("Proxy-Connection")
 


### PR DESCRIPTION
Don't know if this section of code is still being used, but I had to make the change on v2.0 to be able to fuzz with SOCKS proxy.