### PR TITLE
JSON printer enhancements

### DIFF
--- a/plugins/printers.py
+++ b/plugins/printers.py
@@ -328,7 +328,7 @@ class json:
 	    for n, v in res.history.fr_parameters()['post'].items():
                 post_data[n] = v
 
-        res_entry = {"lines": res.lines, "words": res.words, "chars" : res.chars, "url":res.url, "description":res.description, "location" : location, "server" : server, "server" : server, "postdata" : post_data}
+        res_entry = {"lines": res.lines, "words": res.words, "chars": res.chars, "url": res.url, "description": res.description, "location": location, "server": server, "server": server, "postdata": post_data, "code": res.code}
         self.json_res.append(res_entry)
 
     def noresult(self, res):

--- a/plugins/printers.py
+++ b/plugins/printers.py
@@ -323,10 +323,10 @@ class json:
 	    location = res.history.fr_headers()['response']['Location']
 	elif res.history.fr_url() != res.history.fr_redirect_url():
 	    location = "(*) %s" % res.history.fr_url()
-        post_data = {}
+        post_data = []
 	if res.history.fr_method().lower() == "post":
 	    for n, v in res.history.fr_parameters()['post'].items():
-                post_data[n] = v
+                post_data.append({"parameter": n, "value": v})
 
         res_entry = {"lines": res.lines, "words": res.words, "chars": res.chars, "url": res.url, "description": res.description, "location": location, "server": server, "server": server, "postdata": post_data, "code": res.code}
         self.json_res.append(res_entry)


### PR DESCRIPTION
Right now `post_data` is a type of `dict`, but what if we want to fuzz POST parameters that have same names if we are looking for, say, [HTTP Parameter Pollution](https://www.owasp.org/index.php/Testing_for_HTTP_Parameter_pollution_(OTG-INPVAL-004)). 

This PR sets `post_data` to `list` of `dicts`, so parameter names can be non-unique. The format of those dicts becomes more verbose, and easier to unmarshal by external tools. Also the PR adds response code to the top level entry `dict`. 

Cheers