### PR TITLE
Added CSV output to file

### DIFF
--- a/wfuzz/plugins/printers/printers.py
+++ b/wfuzz/plugins/printers/printers.py
@@ -2,7 +2,6 @@ import socket
 import csv as csvmod
 import json as jjson
 from xml.dom import minidom
-import sys
 
 from wfuzz.externals.moduleman.plugin import moduleman_plugin
 from wfuzz.plugin_api.base import BasePrinter

--- a/wfuzz/plugins/printers/printers.py
+++ b/wfuzz/plugins/printers/printers.py
@@ -1,6 +1,8 @@
 import socket
+import csv as csvmod
 import json as jjson
 from xml.dom import minidom
+import sys
 
 from wfuzz.externals.moduleman.plugin import moduleman_plugin
 from wfuzz.plugin_api.base import BasePrinter
@@ -257,3 +259,43 @@ class raw(BasePrinter):
 	    self.f.write("Processed Requests: %s\n" % (str(summary.processed())[:8]))
 	self.f.write("Filtered Requests: %s\n" % (str(summary.filtered())[:8]))
 	self.f.write("Requests/sec.: %s\n" % str(summary.processed()/summary.totaltime if summary.totaltime > 0 else 0)[:8])
+
+@moduleman_plugin
+class csv(BasePrinter):
+    name = "csv"
+    author=("@Yoginski initial version","Adapted by @egilas to work in newer version of wfuzz")
+    summary="CSV printer ftw"
+    version="1.0"
+    category = ["default"]
+    priority = 99
+    
+    def write(self,e):
+        self.f.write(e)
+        pass
+    
+    def __init__(self,output):
+        BasePrinter.__init__(self, output)
+        self.csv_writer = csvmod.writer(self)
+
+    def header(self, summary):
+	self._print_csv(["id", "response", "lines", "word", "chars", "request", "success"])
+
+    def result(self, res):
+        line = [ res.nres,
+                 res.code,
+                 res.lines,
+                 res.words,
+                 res.chars,
+                 res.description,
+                 0 if res.exception else 1]
+        self._print_csv(line)
+
+    def noresult(self, res):
+        pass
+
+    def footer(self, summary):
+        pass
+
+    def _print_csv(self, values):
+	self.csv_writer.writerow(values)
+


### PR DESCRIPTION
Updated printers.py to include CSV output using BasePrinter implementation. Usage:

wfuzz-cli.py -f outputfile.csv,csv ...
or 
wfuzz-cli.py -o csv 