### PR TITLE
Fixed issue when running setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ version = re.search(
 setup(
     name = "wfuzz",
     packages=find_packages(where='src'),
-    package_dir={'wfuzz': 'src/wfuzz/'},
+    package_dir={'wfuzz': 'src/wfuzz'},
     entry_points={
         'console_scripts': [
             'wfuzz = wfuzz.wfuzz:main',


### PR DESCRIPTION
I was receiving the following error when attempting to install wfuzz:

Traceback (most recent call last):
  File "setup.py", line 36, in <module>
    'pyparsing',
  File "C:\Python36\lib\site-packages\setuptools\__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "C:\Python36\lib\distutils\core.py", line 148, in setup
    dist.run_commands()
  File "C:\Python36\lib\distutils\dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "C:\Python36\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "C:\Python36\lib\site-packages\setuptools\command\install.py", line 67, in run
    self.do_egg_install()
  File "C:\Python36\lib\site-packages\setuptools\command\install.py", line 109, in do_egg_install
    self.run_command('bdist_egg')
  File "C:\Python36\lib\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:\Python36\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "C:\Python36\lib\site-packages\setuptools\command\bdist_egg.py", line 161, in run
    self.run_command("egg_info")
  File "C:\Python36\lib\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:\Python36\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "C:\Python36\lib\site-packages\setuptools\command\egg_info.py", line 278, in run
    self.find_sources()
  File "C:\Python36\lib\site-packages\setuptools\command\egg_info.py", line 293, in find_sources
    mm.run()
  File "C:\Python36\lib\site-packages\setuptools\command\egg_info.py", line 524, in run
    self.add_defaults()
  File "C:\Python36\lib\site-packages\setuptools\command\egg_info.py", line 560, in add_defaults
    sdist.add_defaults(self)
  File "C:\Python36\lib\site-packages\setuptools\command\py36compat.py", line 34, in add_defaults
    self._add_defaults_python()
  File "C:\Python36\lib\site-packages\setuptools\command\sdist.py", line 127, in _add_defaults_python
    build_py = self.get_finalized_command('build_py')
  File "C:\Python36\lib\distutils\cmd.py", line 299, in get_finalized_command
    cmd_obj.ensure_finalized()
  File "C:\Python36\lib\distutils\cmd.py", line 107, in ensure_finalized
    self.finalize_options()
  File "C:\Python36\lib\site-packages\setuptools\command\build_py.py", line 34, in finalize_options
    orig.build_py.finalize_options(self)
  File "C:\Python36\lib\distutils\command\build_py.py", line 55, in finalize_options
    self.package_dir[name] = convert_path(path)
  File "C:\Python36\lib\distutils\util.py", line 127, in convert_path
    raise ValueError("path '%s' cannot end with '/'" % pathname)
ValueError: path 'src/wfuzz/' cannot end with '/'

Removing the '/' here fixed the issue.