### PR TITLE
Hotfix 2.3.2

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+# Issue template
+
+## Context
+
+**Please check:**
+
+- [ ] I've read the docs for [Wfuzz](http://wfuzz.readthedocs.io/)
+
+**Please describe your local environment:**
+
+Wfuzz version: Output of wfuzz --version
+
+Python version: Output of python --version
+
+OS: X
+
+## Report
+
+**What is the current behavior?**
+
+X
+
+**What is the expected or desired behavior?**
+
+X
+
+**Please provide steps to reproduce, including exact wfuzz command executed and output:**
+
+X
+
+**Other relevant information:**
+
+X

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -520,7 +520,7 @@ Which is equivalent to::
 
 A more interesting variation of the above examples could be::
 
-    $ wfuzz-cli.py -w fuzzdb/attack/xss/xss-rsnake.txt -d searchFor=FUZZ --filter "intext~FUZZ" http://testphp.vulnweb.com/search.php?test=query
+    $ wfuzz -w fuzzdb/attack/xss/xss-rsnake.txt -d searchFor=FUZZ --filter "content~FUZZ" http://testphp.vulnweb.com/search.php?test=query
 
 Filtering a payload
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -32,7 +32,7 @@ Dependencies
 Wfuzz uses:
 
 * `pycurl <http://pycurl.sourceforge.net/>`_ library to perform HTTP requests.
-* `pyparsing <http://pyparsing.wikispaces.com/>`_ library to create filter's grammars.
+* `pyparsing <https://github.com/pyparsing/pyparsing>`_ library to create filter's grammars.
 * `JSON.miniy (C) Gerald Storer <https://github.com/getify/JSON.minify/blob/master/minify_json.py>`_ to read json recipes.
 
 PyCurl SSL bug

--- a/src/wfuzz/__init__.py
+++ b/src/wfuzz/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'wfuzz'
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 __build__ = 0x023000
 __author__ = 'Xavier Mendez'
 __license__ = 'GPL 2.0'

--- a/src/wfuzz/externals/reqresp/Request.py
+++ b/src/wfuzz/externals/reqresp/Request.py
@@ -334,7 +334,7 @@ class Request:
             else:
                 c.setopt(pycurl.CUSTOMREQUEST, req.method)
 
-            if req.postdata is not None:
+            if req.postdata:
                 c.setopt(pycurl.POSTFIELDS, python2_3_convert_to_unicode(req.postdata))
 
             c.setopt(pycurl.FOLLOWLOCATION, 1 if req.followLocation else 0)

--- a/src/wfuzz/externals/reqresp/Request.py
+++ b/src/wfuzz/externals/reqresp/Request.py
@@ -234,8 +234,7 @@ class Request:
 
         def addHeader(self, key, value):
                 k = string.capwords(key, "-")
-                if k.lower() not in ["accept-encoding", "content-length", "if-modified-since", "if-none-match"]:
-                        self._headers[k] = value
+                self._headers[k] = value
 
         def delHeader(self, key):
             k = string.capwords(key, "-")

--- a/src/wfuzz/externals/reqresp/Request.py
+++ b/src/wfuzz/externals/reqresp/Request.py
@@ -88,7 +88,7 @@ class Request:
         @property
         def method(self):
             if self._method is None:
-                return "POST" if self.postdata else "GET"
+                return "POST" if self.getPOSTVars() else "GET"
 
             return self._method
 
@@ -334,7 +334,7 @@ class Request:
             else:
                 c.setopt(pycurl.CUSTOMREQUEST, req.method)
 
-            if req.postdata:
+            if req.getPOSTVars():
                 c.setopt(pycurl.POSTFIELDS, python2_3_convert_to_unicode(req.postdata))
 
             c.setopt(pycurl.FOLLOWLOCATION, 1 if req.followLocation else 0)

--- a/src/wfuzz/externals/reqresp/Request.py
+++ b/src/wfuzz/externals/reqresp/Request.py
@@ -335,7 +335,7 @@ class Request:
             else:
                 c.setopt(pycurl.CUSTOMREQUEST, req.method)
 
-            if req.postdata:
+            if req.postdata is not None:
                 c.setopt(pycurl.POSTFIELDS, python2_3_convert_to_unicode(req.postdata))
 
             c.setopt(pycurl.FOLLOWLOCATION, 1 if req.followLocation else 0)

--- a/src/wfuzz/externals/reqresp/Variables.py
+++ b/src/wfuzz/externals/reqresp/Variables.py
@@ -64,6 +64,9 @@ class VariablesSet:
         def parseUrlEncoded(self, cad):
                 dicc = []
 
+                if cad == '':
+                    dicc.append(Variable('', None))
+
                 for i in cad.split("&"):
                         if i:
                                 list = i.split("=", 1)

--- a/src/wfuzz/fuzzobjects.py
+++ b/src/wfuzz/fuzzobjects.py
@@ -414,8 +414,8 @@ class FuzzRequest(FuzzRequestUrlMixing, FuzzRequestSoupMixing):
     def to_cache_key(self):
         key = self._request.urlWithoutVariables
 
-        dicc = {f'g{key}': True for key in self.params.get.keys()}
-        dicc.update({f'p{key}': True for key in self.params.post.keys()})
+        dicc = {'g{}'.format(key): True for key in self.params.get.keys()}
+        dicc.update({'p{}'.format(key): True for key in self.params.post.keys()})
 
         # take URL parameters into consideration
         url_params = list(dicc.keys())

--- a/src/wfuzz/fuzzobjects.py
+++ b/src/wfuzz/fuzzobjects.py
@@ -136,7 +136,7 @@ class params(object):
     @post.setter
     def post(self, pp):
         if isinstance(pp, dict):
-            self._req.setPostData("&".join(["=".join([n, v]) if v is not None else n for n, v in list(pp.items())]))
+            self._req.setPostData("&".join(["=".join([n, str(v)]) if v is not None else n for n, v in list(pp.items())]))
         elif isinstance(pp, str):
             self._req.setPostData(pp)
 

--- a/src/wfuzz/fuzzobjects.py
+++ b/src/wfuzz/fuzzobjects.py
@@ -129,6 +129,14 @@ class params(object):
     def get(self):
         return OrderedDict([(x.name, x.value) for x in self._req.getGETVars()])
 
+    @get.setter
+    def get(self, values):
+        if isinstance(values, dict):
+            for key, value in values.items():
+                self._req.setVariableGET(key, value)
+        else:
+            raise FuzzExceptBadAPI("GET Parameters must be specified as a dictionary")
+
     @property
     def post(self):
         return OrderedDict([(x.name, x.value) for x in self._req.getPOSTVars()])

--- a/src/wfuzz/fuzzobjects.py
+++ b/src/wfuzz/fuzzobjects.py
@@ -414,8 +414,8 @@ class FuzzRequest(FuzzRequestUrlMixing, FuzzRequestSoupMixing):
     def to_cache_key(self):
         key = self._request.urlWithoutVariables
 
-        dicc = {key: True for key in self.params.get.keys()}
-        dicc.update({key: True for key in self.params.post.keys()})
+        dicc = {f'g{key}': True for key in self.params.get.keys()}
+        dicc.update({f'p{key}': True for key in self.params.post.keys()})
 
         # take URL parameters into consideration
         url_params = list(dicc.keys())

--- a/tests/test_reqresp.py
+++ b/tests/test_reqresp.py
@@ -132,37 +132,41 @@ class FuzzRequestTest(unittest.TestCase):
 
     def test_cache_key(self):
         fr = FuzzRequest()
-
         fr.url = "http://www.wfuzz.org/"
-        fr.params.get = {'a': '1', 'b': '2'}
-        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-a-b')
-
-        fr = FuzzRequest()
-        fr.url = "http://www.wfuzz.org/"
-        fr.params.post = {'c': '1', 'd': '2'}
-        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-c-d')
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-')
 
         fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.params.get = {'a': '1', 'b': '2'}
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-ga-gb')
+
+        fr = FuzzRequest()
+        fr.url = "http://www.wfuzz.org/"
         fr.params.post = {'c': '1', 'd': '2'}
-        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-a-b-c-d')
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-pc-pd')
+
+        fr = FuzzRequest()
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.get = {'a': '1', 'b': '2'}
+        fr.params.post = {'c': '1', 'd': '2'}
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-ga-gb-pc-pd')
 
         fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.params.get = {'a': '1', 'b': '2'}
         fr.params.post = {'a': '1', 'b': '2'}
-        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-a-b')
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-ga-gb-pa-pb')
 
         fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.params.post = '1'
-        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-1')
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-p1')
 
         fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.params.post = ''
-        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-')
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-p')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_reqresp.py
+++ b/tests/test_reqresp.py
@@ -121,7 +121,7 @@ class FuzzRequestTest(unittest.TestCase):
 
         default_headers = dict([
             ('Content-Type', 'application/x-www-form-urlencoded'),
-            ('User-Agent', f'Wfuzz/{wfuzz_version}'),
+            ('User-Agent', 'Wfuzz/{}'.format(wfuzz_version)),
             ('Host', 'www.wfuzz.org')
         ])
 

--- a/tests/test_reqresp.py
+++ b/tests/test_reqresp.py
@@ -61,6 +61,33 @@ class FuzzRequestTest(unittest.TestCase):
         self.assertEqual(fr.path, "FUZZ")
         self.assertEqual(fr.follow, False)
 
+    def test_setpostdata(self):
+        fr = FuzzRequest()
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = 'a=1'
+        self.assertEqual(fr.method, "POST")
+        self.assertEqual(fr.params.post, {'a': '1'})
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = ''
+        self.assertEqual(fr.method, "POST")
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = {}
+        self.assertEqual(fr.method, "POST")
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = {'a': 1}
+        self.assertEqual(fr.method, "POST")
+        self.assertEqual(fr.params.post, {'a': '1'})
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = {'a': '1'}
+        self.assertEqual(fr.method, "POST")
+        self.assertEqual(fr.params.post, {'a': '1'})
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_reqresp.py
+++ b/tests/test_reqresp.py
@@ -87,6 +87,13 @@ class FuzzRequestTest(unittest.TestCase):
         self.assertEqual(fr.method, "POST")
         self.assertEqual(fr.params.post, {'a': '1'})
 
+    def test_setgetdata(self):
+        fr = FuzzRequest()
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.get = {'a': '1'}
+        self.assertEqual(fr.method, "GET")
+        self.assertEqual(fr.params.get, {'a': '1'})
 
 
 if __name__ == '__main__':

--- a/tests/test_reqresp.py
+++ b/tests/test_reqresp.py
@@ -95,6 +95,53 @@ class FuzzRequestTest(unittest.TestCase):
         self.assertEqual(fr.method, "GET")
         self.assertEqual(fr.params.get, {'a': '1'})
 
+    def test_allvars(self):
+        fr = FuzzRequest()
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.get = {'a': '1', 'b': '2'}
+        fr.wf_allvars = "allvars"
+        self.assertEqual(fr.wf_allvars_set, {'a': '1', 'b': '2'})
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = {'a': '1', 'b': '2'}
+        fr.wf_allvars = "allpost"
+        self.assertEqual(fr.wf_allvars_set, {'a': '1', 'b': '2'})
+
+        default_headers = dict([
+            ('Content-Type', 'application/x-www-form-urlencoded'),
+            ('User-Agent', f'Wfuzz/{wfuzz_version}'),
+            ('Host', 'www.wfuzz.org')
+        ])
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.wf_allvars = "allheaders"
+        self.assertEqual(fr.wf_allvars_set, default_headers)
+
+    def test_cache_key(self):
+        fr = FuzzRequest()
+
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.get = {'a': '1', 'b': '2'}
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-a-b')
+
+        fr = FuzzRequest()
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = {'c': '1', 'd': '2'}
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-c-d')
+
+        fr = FuzzRequest()
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.get = {'a': '1', 'b': '2'}
+        fr.params.post = {'c': '1', 'd': '2'}
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-a-b-c-d')
+
+        fr = FuzzRequest()
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.get = {'a': '1', 'b': '2'}
+        fr.params.post = {'a': '1', 'b': '2'}
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-a-b')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_reqresp.py
+++ b/tests/test_reqresp.py
@@ -63,25 +63,36 @@ class FuzzRequestTest(unittest.TestCase):
 
     def test_setpostdata(self):
         fr = FuzzRequest()
-
         fr.url = "http://www.wfuzz.org/"
         fr.params.post = 'a=1'
         self.assertEqual(fr.method, "POST")
         self.assertEqual(fr.params.post, {'a': '1'})
 
+        fr = FuzzRequest()
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = '1'
+        self.assertEqual(fr.method, "POST")
+        self.assertEqual(fr.params.post, {'1': None})
+
+        fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.params.post = ''
         self.assertEqual(fr.method, "POST")
+        self.assertEqual(fr.params.post, {'': None})
 
+        fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.params.post = {}
-        self.assertEqual(fr.method, "POST")
+        self.assertEqual(fr.method, "GET")
+        self.assertEqual(fr.params.post, {})
 
+        fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.params.post = {'a': 1}
         self.assertEqual(fr.method, "POST")
         self.assertEqual(fr.params.post, {'a': '1'})
 
+        fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.params.post = {'a': '1'}
         self.assertEqual(fr.method, "POST")
@@ -97,12 +108,12 @@ class FuzzRequestTest(unittest.TestCase):
 
     def test_allvars(self):
         fr = FuzzRequest()
-
         fr.url = "http://www.wfuzz.org/"
         fr.params.get = {'a': '1', 'b': '2'}
         fr.wf_allvars = "allvars"
         self.assertEqual(fr.wf_allvars_set, {'a': '1', 'b': '2'})
 
+        fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.params.post = {'a': '1', 'b': '2'}
         fr.wf_allvars = "allpost"
@@ -114,6 +125,7 @@ class FuzzRequestTest(unittest.TestCase):
             ('Host', 'www.wfuzz.org')
         ])
 
+        fr = FuzzRequest()
         fr.url = "http://www.wfuzz.org/"
         fr.wf_allvars = "allheaders"
         self.assertEqual(fr.wf_allvars_set, default_headers)
@@ -142,6 +154,15 @@ class FuzzRequestTest(unittest.TestCase):
         fr.params.post = {'a': '1', 'b': '2'}
         self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-a-b')
 
+        fr = FuzzRequest()
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = '1'
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-1')
+
+        fr = FuzzRequest()
+        fr.url = "http://www.wfuzz.org/"
+        fr.params.post = ''
+        self.assertEqual(fr.to_cache_key(), 'http://www.wfuzz.org/-')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Changes:

- Improve abstraction between FuzzRequest and the underneath HTTP library
- Tests cases for setting FuzzRequest GET/POST parameters
- Tests cases for FuzzRequest cache keys
- FuzzRequest internal Cache differentiates from GET and POST parameters
- Added issue template
- Corrected documentation pyparsing link
- Corrected incorrect documentation XSS example

Bugs fixed:

- Set postdata to an empty string fixes #105 
- Set postdata using a dictionary with an integer value