### PR TITLE
Fix typo of HTTP in proxy options and add support for both types

### DIFF
--- a/src/wfuzz/options.py
+++ b/src/wfuzz/options.py
@@ -127,9 +127,14 @@ class FuzzSession(UserDict):
             raise FuzzExceptBadOptions("Bad options: Incorrect all parameters brute forcing type specified, correct values are allvars,allpost or allheaders.")
 
         if self.data['proxies']:
-            for ip, port, ttype in self.data['proxies']:
+            for i in range(0, len(self.data['proxies'])):
+                ip, port, ttype = self.data['proxies'][i]
+                if ttype == "HTTP":
+                    ttype = "HTML"
+                    self.data['proxies'][i] = (ip, port, ttype)
+
                 if ttype not in ("SOCKS5", "SOCKS4", "HTML"):
-                    raise FuzzExceptBadOptions("Bad proxy type specified, correct values are HTML, SOCKS4 or SOCKS5.")
+                    raise FuzzExceptBadOptions("Bad proxy type specified, correct values are HTTP, SOCKS4 or SOCKS5.")
 
         try:
             if [x for x in ["sc", "sw", "sh", "sl"] if len(self.data[x]) > 0] and \


### PR DESCRIPTION
When launching wfuzz with the `--help` switch, the usage information states the following for the proxy switch:

> Use Proxy in format ip:port:type. Repeat option for using various proxies.
> Where type could be SOCKS4,SOCKS5 or HTTP if omitted.

If one tries to specify `HTTP` as the type, an exception will be thrown with the message:

> Fatal exception: Bad proxy type specified, correct values are HTML, SOCKS4 or SOCKS5.

Seemingly, a typo was made during the implementation of this (i.e. `HTML` instead of `HTTP`).

This pull request fixes the typo in the exception to state `HTTP` as opposed to `HTML` and will also normalise a type of `HTTP` into `HTML` to make usage consistent with the usage guide, but to also retain compatibility for any third parties who may have scripted wfuzz into their own systems with the `HTML` type instead.

## Output Before Patch
### HTML Proxy Type
```shell_session
$ ./wfuzz -p 127.0.0.1:8080:HTML -u http://localhost/FUZZ -w /tmp/wordlist.lst 

Warning: Pycurl is not compiled against Openssl. Wfuzz might not work correctly when fuzzing SSL sites. Check Wfuzz's documentation for more information.

********************************************************
* Wfuzz 2.3.4 - The Web Fuzzer                         *
********************************************************

Target: http://localhost/FUZZ
Total requests: 1

==================================================================
ID   Response   Lines      Word         Chars          Payload    
==================================================================

000001:  C=200     25 L	     155 W	   1356 Ch	  "test"

Total time: 0.012975
Processed Requests: 1
Filtered Requests: 0
Requests/sec.: 77.06576
```
### HTTP Proxy Type
```shell_session
$ ./wfuzz -p 127.0.0.1:8080:HTTP -u http://localhost/FUZZ -w /tmp/wordlist.lst              

Warning: Pycurl is not compiled against Openssl. Wfuzz might not work correctly when fuzzing SSL sites. Check Wfuzz's documentation for more information.


Fatal exception: Bad proxy type specified, correct values are HTML, SOCKS4 or SOCKS5.
```

## Output After Patch
### HTML Proxy Type
```shell_session
$ ./wfuzz -p 127.0.0.1:8080:HTML -u http://localhost/FUZZ -w /tmp/wordlist.lst

Warning: Pycurl is not compiled against Openssl. Wfuzz might not work correctly when fuzzing SSL sites. Check Wfuzz's documentation for more information.

********************************************************
* Wfuzz 2.3.4 - The Web Fuzzer                         *
********************************************************

Target: http://localhost/FUZZ
Total requests: 1

==================================================================
ID   Response   Lines      Word         Chars          Payload    
==================================================================

000001:  C=200     25 L	     155 W	   1356 Ch	  "test"

Total time: 0.012984
Processed Requests: 1
Filtered Requests: 0
Requests/sec.: 77.01198
```

### HTTP Proxy Type
```shell_session
$ ./wfuzz -p 127.0.0.1:8080:HTTP -u http://localhost/FUZZ -w /tmp/wordlist.lst

Warning: Pycurl is not compiled against Openssl. Wfuzz might not work correctly when fuzzing SSL sites. Check Wfuzz's documentation for more information.

********************************************************
* Wfuzz 2.3.4 - The Web Fuzzer                         *
********************************************************

Target: http://localhost/FUZZ
Total requests: 1

==================================================================
ID   Response   Lines      Word         Chars          Payload    
==================================================================

000001:  C=200     25 L	     155 W	   1356 Ch	  "test"

Total time: 0.012972
Processed Requests: 1
Filtered Requests: 0
Requests/sec.: 77.08417
```

### Invalid Proxy Type
```shell_session
$ ./wfuzz -p 127.0.0.1:8080:INVALID -u http://localhost/FUZZ -w /tmp/wordlist.lst

Warning: Pycurl is not compiled against Openssl. Wfuzz might not work correctly when fuzzing SSL sites. Check Wfuzz's documentation for more information.


Fatal exception: Bad proxy type specified, correct values are HTTP, SOCKS4 or SOCKS5.
```
### No Proxy Type Specified
```shell_session
$ ./wfuzz -p 127.0.0.1:8080 -u http://localhost/FUZZ -w /tmp/wordlist.lst        

Warning: Pycurl is not compiled against Openssl. Wfuzz might not work correctly when fuzzing SSL sites. Check Wfuzz's documentation for more information.

********************************************************
* Wfuzz 2.3.4 - The Web Fuzzer                         *
********************************************************

Target: http://localhost/FUZZ
Total requests: 1

==================================================================
ID   Response   Lines      Word         Chars          Payload    
==================================================================

000001:  C=200     25 L	     155 W	   1356 Ch	  "test"

Total time: 0.013109
Processed Requests: 1
Filtered Requests: 0
Requests/sec.: 76.27810
```
