### PR TITLE
Update installation docs for macOS

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -59,15 +59,15 @@ This is due to the fact that, MacOS might need some tweaks before pycurl is inst
 
 #. Curl is normally already installed in MacOs, but to be sure it uses OpenSSL, we need to install it using brew::
 
-    $ brew install curl --with-openssl
+    $ brew install curl-openssl
 
 #. Curl is installed keg-only by brew. This means that is installed but not linked. Therefore, we need to instruct pip to use the recently installed curl before installing pycurl. We can do this permanently by changing our bash_profile::
 
-    $ echo 'export PATH="/usr/local/opt/curl/bin:$PATH"' >> ~/.bash_profile
+    $ echo 'export PATH="/usr/local/opt/curl-openssl/bin:$PATH"' >> ~/.bash_profile
 
 #. Or temporary in the current shell::
 
-    $ export PATH="/usr/local/opt/curl/bin:$PATH"
+    $ export PATH="/usr/local/opt/curl-openssl/bin:$PATH"
 
 #. Then, we need to install pycurl as follows::
 


### PR DESCRIPTION
Installing curl using brew doesn't support the `--with-openssl` anymore
curl-openssl package can be used to achieve similar outcome
Tested on Mojave 10.14.4 using Homebrew 2.1.1, pip 19.1