### PR TITLE
Add shodan package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,18 @@
 #
 #    pip-compile --output-file requirements.txt setup.py
 #
+certifi==2019.6.16        # via requests
 chardet==3.0.4
+click-plugins==1.1.1      # via shodan
+click==7.0                # via click-plugins, shodan
+colorama==0.4.1           # via shodan
 configparser==3.5.0
 future==0.17.1
+idna==2.8                 # via requests
 pycurl==7.43.0.2
 pyparsing==2.3.0
+requests==2.22.0          # via shodan
+shodan==1.13.0
 six==1.11.0
+urllib3==1.25.3           # via requests
+xlsxwriter==1.1.8         # via shodan

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     'six',
     'configparser;python_version<"3.5"',
     'chardet',
+    'shodan',
 ]
 
 if sys.platform.startswith("win"):


### PR DESCRIPTION
Hey, I noticed that we don't install `shodan` package by default and wfuzz is complaining about it:
```
libraries.FileLoader: CRITICAL __load_py_from_file. Filename: /usr/lib/python3.7/site-packages/wfuzz/plugins/payloads/bing.py Exception, msg=No module named 'shodan'
libraries.FileLoader: CRITICAL __load_py_from_file. Filename: /usr/lib/python3.7/site-packages/wfuzz/plugins/payloads/shodanp.py Exception, msg=No module named 'shodan'
```

It was added to `setup.py` and I did `pip-compile` to update `requirements.txt`.