### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     author="Xavi Mendez (@x4vi_mendez)",
     author_email="xmendez@edge-security.com",
     url="http://wfuzz.org",
+    license="GPLv2",
     install_requires=install_requires,
     extras_require={
         'dev': dev_requires,


### PR DESCRIPTION
This is often parsed by third-party tools, e.g., `pyp2rpm`.