### PR TITLE
Removed deprecation warning from "collections"

### DIFF
--- a/src/wfuzz/externals/moduleman/registrant.py
+++ b/src/wfuzz/externals/moduleman/registrant.py
@@ -1,5 +1,6 @@
 from .modulefilter import Filter
-from collections import defaultdict, MutableMapping
+from collections import defaultdict
+from collections.abc import MutableMapping
 from threading import Lock
 
 

--- a/src/wfuzz/options.py
+++ b/src/wfuzz/options.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 
 # python 2 and 3
 try:
-    from collections import UserDict
+    from collections.abc import UserDict
 except ImportError:
     from UserDict import UserDict
 

--- a/src/wfuzz/options.py
+++ b/src/wfuzz/options.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 
 # python 2 and 3
 try:
-    from collections.abc import UserDict
+    from collections import UserDict
 except ImportError:
     from UserDict import UserDict
 


### PR DESCRIPTION
The deprecation warning is related with the `collections` module and its abstract counterpart `collections.abc` so the solution only needs to change the import.

The message is:
`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working`