### PR TITLE
Relax pycurl version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ dev_requires = [
 ]
 
 install_requires = [
-    'pycurl<=7.43.0.3',
+    'pycurl<7.43.1',
     'pyparsing',
     'future',
     'six',


### PR DESCRIPTION
Is such a strict pycurl version requirement really necessary? It prevented the package from working on Arch Linux where pycurl is currently at 7.43.0.5. I relaxed the requirement for the [AUR package](https://aur.archlinux.org/packages/wfuzz/) and it seems it works correctly.