### PR TITLE
Added JSON encoder plugin

### DIFF
--- a/src/wfuzz/plugins/encoders/encoders.py
+++ b/src/wfuzz/plugins/encoders/encoders.py
@@ -21,6 +21,7 @@ import binascii
 import random
 import hashlib
 import html
+import json
 
 
 @moduleman_plugin("encode")
@@ -467,3 +468,21 @@ class oracle_char:
             x = x.strip("chr").strip(")").strip("(")
             new += chr(int(x))
         return new
+
+
+@moduleman_plugin("encode")
+class jsonencode:
+    name = "jsonencode"
+    author = ("Denis Andzakovic (@denandz)")
+    version = "0.1"
+    summary = "Serializes strings to JSON, escaping special characters"
+    category = ["json"]
+    priority = 99
+
+    def encode(self, string):
+        new = json.dumps(string)[1:-1]  # json.dumps wraps output in double quotes, strip 'em
+        return new
+
+    def decode(self, string):
+        new = '"' + string + '"'  # add the quotes back in....
+        return json.loads(new)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,6 +50,8 @@ class APITests(unittest.TestCase):
             'mysql_char': ('admin', 'CHAR(97,100,109,105,110)'),
             'mssql_char': ('admin', 'CHAR(97)+CHAR(100)+CHAR(109)+CHAR(105)+CHAR(110)'),
             'oracle_char': ('admin', 'chr(97)||chr(100)||chr(109)||chr(105)||chr(110)'),
+
+            'jsonencode': ('test"value\\x', 'test\\"value\\\\x'),
         }
 
         for key, values in list(encoders.items()):


### PR DESCRIPTION
Added a JSON encoder plugin, which runs every payload through `json.dumps()`. Consider the following string:

```
" or "a"="a
```

When attacking a JSON API, using the `jsonencode` plugin will escape any problematic characters and produce valid JSON, eg:

```
\" or \"a\"=\"a
```

This encoder allows targeting payloads against whatever is reading and processing the data in the JSON body, rather than breaking the JSON parser.