### PR TITLE
Fix use proxy SOCKS5/4

### DIFF
--- a/src/wfuzz/myhttp.py
+++ b/src/wfuzz/myhttp.py
@@ -135,8 +135,10 @@ class HttpPool:
 
             if ptype == "SOCKS5":
                 c.setopt(pycurl.PROXYTYPE, pycurl.PROXYTYPE_SOCKS5)
+                c.setopt(pycurl.PROXY, "%s:%s" % (ip, port))
             elif ptype == "SOCKS4":
                 c.setopt(pycurl.PROXYTYPE, pycurl.PROXYTYPE_SOCKS4)
+                c.setopt(pycurl.PROXY, "%s:%s" % (ip, port))
             elif ptype == "HTTP":
                 c.setopt(pycurl.PROXY, "%s:%s" % (ip, port))
             else:


### PR DESCRIPTION
In code myhttp.py:136 setopt type proxy for pycurl but not indicate ip & port... I add  c.setopt(pycurl.PROXY, "%s:%s" % (ip, port)) for SOCKS4 and SOCKS5 and now it's work!

Thanks for your tool! It's really great.
Lionel