### PR TITLE
setup.py: invalid requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ dev_requires = [
 install_requires = [
     'pycurl',
     'pyparsing<2.4.2;python_version<="3.4"',
-    'pyparsing>2.4.2;python_version>="3.5"',
+    'pyparsing>=2.4*;python_version>="3.5"',
     'future',
     'six',
     'configparser;python_version<"3.5"',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ dev_requires = [
 install_requires = [
     'pycurl',
     'pyparsing<2.4.2;python_version<="3.4"',
-    'pyparsing>2.4*;python_version>="3.5"',
+    'pyparsing>2.4.2;python_version>="3.5"',
     'future',
     'six',
     'configparser;python_version<"3.5"',


### PR DESCRIPTION
The current "install_requires" condition cannot be match. pyparsing>2.4* means version 3. Later, wfuzz fails with the following error:
```
wfuzz 
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (pyparsing 2.4.7 (/usr/lib/python3.7/site-packages), Requirement.parse('pyparsing>3*'), {'wfuzz'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.7/wfuzz", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3251, in <module>
    @_call_aside
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 585, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 598, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pyparsing>3*' distribution was not found and is required by wfuzz
```