### PR TITLE
Update plugin screenshot to : allow insecure https and add details in filename

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,16 @@
 #
 #    pip-compile --output-file=requirements.txt setup.py
 #
-attrs==19.3.0             # via pytest
+attrs==20.1.0             # via pytest
 chardet==3.0.4            # via wfuzz (setup.py)
 future==0.18.2            # via wfuzz (setup.py)
-more-itertools==8.3.0     # via pytest
+iniconfig==1.0.1          # via pytest
+more-itertools==8.5.0     # via pytest
 packaging==20.4           # via pytest
 pluggy==0.13.1            # via pytest
-py==1.8.1                 # via pytest
+py==1.9.0                 # via pytest
 pycurl==7.43.0.5          # via wfuzz (setup.py)
 pyparsing==2.4.7          # via packaging
-pytest==5.4.2             # via wfuzz (setup.py)
-six==1.14.0               # via packaging, wfuzz (setup.py)
-wcwidth==0.1.9            # via pytest
+pytest==6.0.1             # via wfuzz (setup.py)
+six==1.15.0               # via packaging, wfuzz (setup.py)
+toml==0.10.1              # via pytest

--- a/src/wfuzz/plugins/scripts/screenshot.py
+++ b/src/wfuzz/plugins/scripts/screenshot.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 import pipes
 import os
-
+import re
 
 @moduleman_plugin
 class screenshot(BasePlugin):
@@ -32,13 +32,15 @@ class screenshot(BasePlugin):
         temp_name = next(tempfile._get_candidate_names())
         defult_tmp_dir = tempfile._get_default_tempdir()
 
-        filename = os.path.join(defult_tmp_dir, temp_name + ".png")
+        filename = os.path.join(defult_tmp_dir, (temp_name+'_'+re.sub('[^a-zA-Z0-9_\-]','_',fuzzresult.url))[:200] + ".jpg")
 
         subprocess.call(
             [
                 "cutycapt",
                 "--url=%s" % pipes.quote(fuzzresult.url),
                 "--out=%s" % filename,
+                "--insecure",
+                "--print-backgrounds=on"
             ]
         )
         self.add_result("Screnshot taken, output at %s" % filename)


### PR DESCRIPTION
- Allow insecure https to avoid bad rendering
- Add the full url ( stripped with bad chars) in the file name
- Change png to jpg in order to reduce the screenshot's size