### PR TITLE
FuzzPlugin severity

### DIFF
--- a/src/wfuzz/fuzzobjects.py
+++ b/src/wfuzz/fuzzobjects.py
@@ -421,7 +421,7 @@ class FuzzPlugin(FuzzItem):
         if verbose and self.itype == self.SUMMARY_ITYPE:
             return False
 
-        if not verbose and self.severity >= self.MIN_VERBOSE:
+        if not verbose and self.severity < self.MIN_VERBOSE:
             return False
 
         return True


### PR DESCRIPTION
Hi, I noticed issues running `--script`, that some were outputing fairly useless messages unless `-v` for verbose messages was specified.

For example, the `title` script would output a message that the `title` script generated a message, but not say what the message is.

I believe this is due to a logic error in `is_visible`, identified in this pull request's changes.

Currently in the codebase, all scripts generate results of severity `FuzzPlugin.INFO` which should be displayed as the hardcoded `MIN_VERBOSE` is also equal to `INFO`.