### PR TITLE
Correct dependency specification for pyparsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requires = [
 install_requires = [
     'pycurl',
     'pyparsing<2.4.2;python_version<="3.4"',
-    'pyparsing>=2.4*;python_version>="3.5"',
+    'pyparsing>=2.4.2;python_version>="3.5"',
     'six',
     'configparser;python_version<"3.5"',
     'chardet',


### PR DESCRIPTION
wildcard(*) is not allowed in inclusive comparison:
https://peps.python.org/pep-0440/#inclusive-ordered-comparison

Version is adjusted according to:
https://github.com/xmendez/wfuzz/issues/206#issuecomment-673519577

Fixes: https://github.com/xmendez/wfuzz/issues/345