### PR TITLE
Fix pip 24.1 requirement syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requires = [
 install_requires = [
     'pycurl',
     'pyparsing<2.4.2;python_version<="3.4"',
-    'pyparsing>=2.4*;python_version>="3.5"',
+    'pyparsing>=2.4.2;python_version>="3.5"',
     'six',
     'configparser;python_version<"3.5"',
     'chardet',


### PR DESCRIPTION
Linked to issue: https://github.com/xmendez/wfuzz/issues/366
Since pip 24.1, the `*` syntax is no longer supported in the `install_requires` section.
