### PR TITLE
Security: upgrade py to 1.10.0 to fix CVE-2020-29651 ReDoS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ iniconfig==1.0.1          # via pytest
 more-itertools==8.5.0     # via pytest
 packaging==20.4           # via pytest
 pluggy==0.13.1            # via pytest
-py==1.9.0                 # via pytest
+py==1.10.0                # via pytest
 pycurl==7.43.0.6          # via wfuzz (setup.py)
 pyparsing==2.4.7          # via packaging
 pytest==6.0.1             # via wfuzz (setup.py)


### PR DESCRIPTION
### Description
This PR upgrades the `py` dependency (used via `pytest`) from `1.9.0` to `1.10.0` to resolve a known security vulnerability.

### Security Details
- **Vulnerability:** Regular Expression Denial of Service (ReDoS)
- **CWE:** CWE-400
- **CVE:** [CVE-2020-29651](https://nvd.nist.gov/vuln/detail/CVE-2020-29651)
- **Severity:** Medium / High (depending on the environment)

### Impact
In `py < 1.10.0`, the regular expression subpattern `\d+\s*\S+` used in SVN blame parsing is ambiguous. This makes the pattern subject to catastrophic backtracking when evaluating specifically crafted long strings (e.g., `"1" * 5000`), causing CPU exhaustion and a subsequent Denial of Service (DoS). 

Upgrading to `py>=1.10.0` fixes the ambiguity by changing the `*` quantifier to `+`.