### PR TITLE
fix: update base image from python:3.8-alpine3.12 to python:3.11-alpi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,9 @@
-FROM python:3.8-alpine3.12 as builder
-
+FROM python:3.11-alpine3.21 as builder
 RUN apk add --no-cache build-base curl-dev
-
 COPY . wfuzz/
-
 WORKDIR wfuzz/
-
 RUN python setup.py install
-
-
-FROM python:3.8-alpine3.12
-
+FROM python:3.11-alpine3.21
 RUN apk add --no-cache curl-dev
-
 COPY --from=builder /usr/local /usr/local
-
 CMD wfuzz


### PR DESCRIPTION
…ne3.21

- Alpine 3.12 is EOL and no longer receives security updates
- python:3.8-alpine3.12 carries 10 Critical and 23 High CVEs
- python:3.11-alpine3.21 eliminates all Critical vulnerabilities
- Python 3.13 was tested but incompatible (wfuzz uses removed 'imp' module)
- Python 3.11 is supported until October 2027