### PR TITLE
fix: replace pkg_resources with importlib.resources in file_func.py

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,49 @@
+name: CodSpeed
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # for OpenID Connect authentication with CodSpeed
+
+jobs:
+  benchmarks:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install libcurl headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # setuptools is required at runtime: wfuzz still imports distutils,
+          # which is no longer part of the standard library on Python 3.12+.
+          pip install setuptools
+          # netaddr is needed by the ipnet/iprange payloads.
+          pip install netaddr
+          pip install pytest pytest-codspeed
+          pip install -e .
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v5
+        with:
+          mode: simulation
+          run: pytest benchmarks/ --codspeed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
-FROM python:3.8-alpine3.12 as builder
-
+FROM python:3.13-alpine3.21 as builder
 RUN apk add --no-cache build-base curl-dev
-
+RUN pip install --no-cache-dir setuptools pycurl chardet pyparsing
 COPY . wfuzz/
-
 WORKDIR wfuzz/
-
 RUN python setup.py install
-
-
-FROM python:3.8-alpine3.12
-
+FROM python:3.13-alpine3.21
 RUN apk add --no-cache curl-dev
-
 COPY --from=builder /usr/local /usr/local
-
 CMD wfuzz

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ tox:
 	tox --recreate
 test:
 	pytest -v -s tests/
+bench:
+	pytest benchmarks/ --codspeed
 flake8:
 	black --check src tests
 	flake8 src tests
@@ -36,6 +38,7 @@ freeze:
 help:
 	@echo "make help              Show this help message"
 	@echo "make test              Run local tests with tox"
+	@echo "make bench             Run the CodSpeed benchmarks"
 	@echo "make flake8            Run the code linter(s) and print any warnings"
 	@echo "make publish           Publish pip lib to pypi"
 	@echo "make publish-dev       Publish pip lib to pypi test"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+> ⚠️ **Fork mantenuto da [@maksimtech](https://github.com/maksimtech)**
+> 
+> Questa versione supporta **Python 3.13+** e **Alpine 3.21**.
+> Il progetto originale [xmendez/wfuzz](https://github.com/xmendez/wfuzz) 
+> non è più attivamente mantenuto.
+>
+> **Modifiche rispetto all'originale:**
+> - `imp` → `importlib.util` (rimosso in Python 3.12)
+> - `cgi` → `email.message` (rimosso in Python 3.13)
+> - `pkg_resources` → `importlib.resources`
+> - `six` rimosso — codice Python 3 nativo
+> - Dockerfile aggiornato a `python:3.13-alpine3.21`
+> - Dipendenze legacy pulite da `setup.py`
+
 <img src="https://github.com/xmendez/wfuzz/blob/master/docs/_static/logo/wfuzz_letters.svg" width="500">
 
 [![Build Status](https://travis-ci.org/xmendez/wfuzz.svg?branch=master)](https://travis-ci.org/xmendez/wfuzz)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 <a href="https://pypi.python.org/pypi/wfuzz"><img src="https://img.shields.io/pypi/dm/wfuzz"></a>
 <a href="https://pypi.python.org/pypi/wfuzz"><img src="https://img.shields.io/pypi/pyversions/wfuzz.svg"></a>
 <a href="https://codecov.io/github/xmendez/wfuzz"><img src="https://codecov.io/github/xmendez/wfuzz/coverage.svg?branch=master"></a>
+<a href="https://app.codspeed.io/maksimtech/wfuzz?utm_source=badge"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed"/></a>
 
 
 # Wfuzz - The Web Fuzzer

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,40 @@
+# Benchmarks
+
+Performance benchmarks for wfuzz, written with
+[pytest-codspeed](https://codspeed.io/docs/benchmarks/python) and continuously
+measured on [CodSpeed](https://app.codspeed.io/maksimtech/wfuzz).
+
+They cover the code paths that are executed for every request wfuzz sends:
+
+| File                       | Covers                                                              |
+| -------------------------- | ------------------------------------------------------------------- |
+| `test_bench_encoders.py`   | Payload encoders/decoders (url, hex, hash, html, db) over a wordlist |
+| `test_bench_payloads.py`   | Payload plugins: range, hexrange, permutation, list, file, ipnet...  |
+| `test_bench_iterators.py`  | Payload combination iterators: zip, chain, product                   |
+| `test_bench_request.py`    | Raw HTTP request/response parsing and FuzzResult computation         |
+| `test_bench_filters.py`    | Filter language creation and evaluation (`--filter`, `--hc`, `--ss`) |
+| `test_bench_helpers.py`    | Case insensitive dicts, dynamic field lookup, string helpers         |
+| `test_bench_clparser.py`   | Command line parsing (startup cost)                                  |
+
+The benchmarks are self-contained: they do not perform any network request, so
+they can be run anywhere.
+
+## Running locally
+
+```
+pip install setuptools netaddr pytest pytest-codspeed
+pip install -e .
+
+# plain run, checks that the benchmarks are functional
+pytest benchmarks/
+
+# measured run
+make bench
+```
+
+To get the same measurements as in CI, use the
+[CodSpeed CLI](https://codspeed.io/docs/cli):
+
+```
+codspeed run --mode simulation -- pytest benchmarks/ --codspeed
+```

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,119 @@
+import os
+
+import pytest
+
+from wfuzz.fuzzobjects import FuzzResult
+from wfuzz.fuzzrequest import FuzzRequest
+
+REPO_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+COMMON_WORDLIST = os.path.join(REPO_DIR, "wordlist", "general", "common.txt")
+
+RAW_REQUEST = """GET /admin/login.php?id=1&lang=en&redirect=%2Fhome HTTP/1.1
+Host: www.wfuzz.org
+User-Agent: Wfuzz/3.1.0
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate
+Cookie: session=39ad7bcb9a0f4c0b; lang=en; consent=1
+Connection: close
+
+"""
+
+RAW_POST_REQUEST = """POST /admin/login.php HTTP/1.1
+Host: www.wfuzz.org
+User-Agent: Wfuzz/3.1.0
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 61
+Cookie: session=39ad7bcb9a0f4c0b
+
+user=admin&password=admin&remember=1&csrf=39ad7bcb9a0f4c0b0e2a
+"""
+
+RAW_RESPONSE_HEADERS = """HTTP/1.1 200 OK
+Date: Wed, 23 Jan 2019 21:43:59 GMT
+Content-Type: text/html; charset=utf-8
+Server: nginx/1.14.0 (Ubuntu)
+Set-Cookie: session=39ad7bcb9a0f4c0b; Path=/; HttpOnly
+Vary: Accept-Language, Cookie
+X-Frame-Options: SAMEORIGIN
+Content-Length: {content_length}
+
+{content}"""
+
+
+def build_html_page(rows=150):
+    """Build a deterministic HTML page, representative of a crawled response."""
+    parts = [
+        "<html><head><title>Wfuzz benchmark page</title>",
+        '<link rel="stylesheet" href="/static/main.css">',
+        "</head><body>",
+        '<div id="content">',
+    ]
+
+    for i in range(rows):
+        parts.append(
+            '<div class="row"><a href="/dir{i}/item{i}.html?id={i}&amp;ref=list">'
+            "Item {i}</a>"
+            '<img src="/static/img/thumb{i}.png" alt="thumb {i}"/>'
+            "<p>Some textual content for the item number {i}, used to make the "
+            "response body large enough to be representative.</p></div>".format(i=i)
+        )
+
+    parts.append("</div>")
+    parts.append('<script src="/static/js/app.js"></script>')
+    parts.append("</body></html>")
+
+    return "\n".join(parts)
+
+
+HTML_PAGE = build_html_page()
+
+
+@pytest.fixture(scope="session")
+def words():
+    """A realistic list of fuzzing words, taken from the shipped wordlists."""
+    with open(COMMON_WORDLIST) as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+@pytest.fixture(scope="session")
+def common_wordlist_path():
+    return COMMON_WORDLIST
+
+
+@pytest.fixture(scope="session")
+def html_page():
+    return HTML_PAGE
+
+
+@pytest.fixture(scope="session")
+def raw_request():
+    return RAW_REQUEST
+
+
+@pytest.fixture(scope="session")
+def raw_post_request():
+    return RAW_POST_REQUEST
+
+
+@pytest.fixture(scope="session")
+def raw_response():
+    return RAW_RESPONSE_HEADERS.format(
+        content_length=len(HTML_PAGE), content=HTML_PAGE
+    ).encode("utf-8")
+
+
+def make_fuzz_result(raw_req=RAW_REQUEST, content=HTML_PAGE):
+    raw_resp = RAW_RESPONSE_HEADERS.format(
+        content_length=len(content), content=content
+    ).encode("utf-8")
+
+    request = FuzzRequest()
+    request.update_from_raw_http(raw_req, "http", raw_resp, content.encode("utf-8"))
+
+    return FuzzResult(history=request).update()
+
+
+@pytest.fixture
+def fuzz_result():
+    return make_fuzz_result()

--- a/benchmarks/test_bench_clparser.py
+++ b/benchmarks/test_bench_clparser.py
@@ -1,0 +1,52 @@
+"""Benchmarks for the command line parser.
+
+Parsing the command line happens once per run, but it validates every option and
+builds the session options, so it is a good proxy for the wfuzz startup cost.
+"""
+
+import pytest
+
+from wfuzz.ui.console.clparser import CLParser
+
+COMMAND_LINES = {
+    "simple": ["wfuzz", "-z", "range,0-100", "http://localhost/FUZZ"],
+    "filters": [
+        "wfuzz",
+        "-z",
+        "file,wordlist/general/common.txt",
+        "--hc",
+        "404,403",
+        "--hw",
+        "10",
+        "--filter",
+        "c=200 and l>2",
+        "http://localhost/FUZZ",
+    ],
+    "multiple_payloads": [
+        "wfuzz",
+        "-z",
+        "range,0-10",
+        "--zE",
+        "md5",
+        "-z",
+        "list,a-b-c",
+        "-m",
+        "zip",
+        "-b",
+        "session=1",
+        "-H",
+        "User-Agent: bench",
+        "-d",
+        "user=FUZZ&password=FUZ2Z",
+        "http://localhost/login",
+    ],
+}
+
+
+@pytest.mark.parametrize("command_line", sorted(COMMAND_LINES))
+def test_parse_command_line(benchmark, command_line):
+    argv = COMMAND_LINES[command_line]
+
+    options = benchmark(lambda: CLParser(list(argv)).parse_cl())
+
+    assert options.data["payloads"]

--- a/benchmarks/test_bench_encoders.py
+++ b/benchmarks/test_bench_encoders.py
@@ -1,0 +1,92 @@
+"""Benchmarks for the payload encoders.
+
+Encoders are applied to every single word of a wordlist while fuzzing, so they
+sit on the hottest path of wfuzz.
+"""
+
+import pytest
+
+from wfuzz.plugins.encoders.encoders import (
+    base64,
+    double_urlencode,
+    first_nibble_hex,
+    hexlify,
+    html_escape,
+    md5,
+    mssql_char,
+    mysql_char,
+    oracle_char,
+    sha1,
+    sha256,
+    uri_double_hex,
+    uri_hex,
+    uri_unicode,
+    urlencode,
+    utf8,
+)
+
+ENCODERS = {
+    "urlencode": urlencode,
+    "double_urlencode": double_urlencode,
+    "uri_hex": uri_hex,
+    "uri_double_hex": uri_double_hex,
+    "uri_unicode": uri_unicode,
+    "first_nibble_hex": first_nibble_hex,
+    "base64": base64,
+    "hexlify": hexlify,
+    "md5": md5,
+    "sha1": sha1,
+    "sha256": sha256,
+    "html_escape": html_escape,
+    "utf8": utf8,
+    "mysql_char": mysql_char,
+    "mssql_char": mssql_char,
+    "oracle_char": oracle_char,
+}
+
+DECODERS = ["urlencode", "double_urlencode", "base64", "hexlify", "mysql_char"]
+
+
+@pytest.mark.parametrize("encoder_name", sorted(ENCODERS))
+def test_encode_wordlist(benchmark, words, encoder_name):
+    encoder = ENCODERS[encoder_name]()
+
+    encoded = benchmark(lambda: [encoder.encode(word) for word in words])
+
+    assert len(encoded) == len(words)
+
+
+@pytest.mark.parametrize("encoder_name", sorted(DECODERS))
+def test_decode_wordlist(benchmark, words, encoder_name):
+    encoder = ENCODERS[encoder_name]()
+    encoded = [encoder.encode(word) for word in words]
+
+    decoded = benchmark(lambda: [encoder.decode(word) for word in encoded])
+
+    assert decoded == words
+
+
+def test_encode_chained_encoders(benchmark, words):
+    """Equivalent of the `md5@urlencode@base64` chained encoder syntax."""
+    chain = [base64(), urlencode(), md5()]
+
+    def run():
+        result = []
+        for word in words:
+            value = word
+            for encoder in chain:
+                value = encoder.encode(value)
+            result.append(value)
+        return result
+
+    assert len(benchmark(run)) == len(words)
+
+
+def test_encode_injection_payloads(benchmark, words):
+    """Encoding of special characters, the worst case for the url encoders."""
+    payloads = ["../../etc/passwd?a=1&b=<script>'\"%s" % word for word in words[:200]]
+    encoder = urlencode()
+
+    assert len(benchmark(lambda: [encoder.encode(p) for p in payloads])) == len(
+        payloads
+    )

--- a/benchmarks/test_bench_filters.py
+++ b/benchmarks/test_bench_filters.py
@@ -1,0 +1,63 @@
+"""Benchmarks for the result filters.
+
+The filter language is evaluated for every single result, and the pyparsing
+grammar is built every time a filter is created.
+"""
+
+import re
+
+import pytest
+
+from wfuzz.filters.ppfilter import FuzzResFilter
+from wfuzz.filters.simplefilter import FuzzResSimpleFilter
+
+FILTERS = {
+    "code": "c=200",
+    "size": "l>2 and w>100 and h>1000",
+    "header": "r.headers.response.Server~'nginx'",
+    "content": "content~'benchmark' and not content~'missing'",
+    "url_params": "r.params.get.lang='en' and r.url~'login'",
+    "nested": "(c=200 and w>10) or (c=404 and w<10)",
+}
+
+
+@pytest.mark.parametrize("filter_name", sorted(FILTERS))
+def test_filter_creation(benchmark, filter_name):
+    filter_string = FILTERS[filter_name]
+
+    ffilter = benchmark(lambda: FuzzResFilter(filter_string=filter_string))
+
+    assert ffilter is not None
+
+
+@pytest.mark.parametrize("filter_name", sorted(FILTERS))
+def test_filter_is_visible(benchmark, fuzz_result, filter_name):
+    ffilter = FuzzResFilter(filter_string=FILTERS[filter_name])
+
+    assert benchmark(lambda: ffilter.is_visible(fuzz_result)) is not None
+
+
+def test_filter_is_visible_many_results(benchmark, fuzz_result):
+    """Filtering a batch of results, as done when consuming a wordlist."""
+    ffilter = FuzzResFilter(filter_string=FILTERS["size"])
+    results = [fuzz_result] * 100
+
+    assert len(benchmark(lambda: [ffilter.is_visible(r) for r in results])) == 100
+
+
+def test_simple_filter_codes(benchmark, fuzz_result):
+    ffilter = FuzzResSimpleFilter()
+    ffilter.hideparams["codes_show"] = False
+    ffilter.hideparams["codes"] = [404, 403, 500]
+    results = [fuzz_result] * 100
+
+    assert all(benchmark(lambda: [ffilter.is_visible(r) for r in results]))
+
+
+def test_simple_filter_regex(benchmark, fuzz_result):
+    ffilter = FuzzResSimpleFilter()
+    ffilter.hideparams["regex_show"] = True
+    ffilter.hideparams["regex"] = re.compile("Item 149", re.MULTILINE | re.DOTALL)
+    results = [fuzz_result] * 20
+
+    assert all(benchmark(lambda: [ffilter.is_visible(r) for r in results]))

--- a/benchmarks/test_bench_helpers.py
+++ b/benchmarks/test_bench_helpers.py
@@ -1,0 +1,93 @@
+"""Benchmarks for the internal helpers.
+
+These small utilities are used pervasively: the case insensitive dictionaries
+back the HTTP headers/params and the dynamic attribute lookup backs the filter
+language.
+"""
+
+from wfuzz.helpers.obj_dic import CaseInsensitiveDict, DotDict
+from wfuzz.helpers.obj_dyn import rgetattr, rsetattr
+from wfuzz.helpers.str_func import json_minify, value_in_any_list_item
+
+HEADERS = {
+    "Content-Type": "text/html; charset=utf-8",
+    "Server": "nginx/1.14.0 (Ubuntu)",
+    "Set-Cookie": "session=39ad7bcb9a0f4c0b; Path=/; HttpOnly",
+    "Vary": "Accept-Language, Cookie",
+    "X-Frame-Options": "SAMEORIGIN",
+    "Content-Length": "37966",
+    "Date": "Wed, 23 Jan 2019 21:43:59 GMT",
+}
+
+JSON_DOCUMENT = """
+{
+    // a comment
+    "results": [
+%s
+    ]
+}
+""" % (
+    ",\n".join(
+        '        {"id": %d, "url": "/dir%d/item%d.html", "code": 200}' % (i, i, i)
+        for i in range(25)
+    )
+)
+
+
+def test_case_insensitive_dict_build(benchmark):
+    def run():
+        headers = CaseInsensitiveDict()
+        for key, value in HEADERS.items():
+            headers[key] = value
+        return headers
+
+    assert benchmark(run)["server"].startswith("nginx")
+
+
+def test_case_insensitive_dict_lookup(benchmark):
+    headers = CaseInsensitiveDict(HEADERS)
+    keys = ["content-type", "SERVER", "Set-Cookie", "vary", "content-length"] * 20
+
+    assert len(benchmark(lambda: [headers[key] for key in keys])) == len(keys)
+
+
+def test_dot_dict_access(benchmark):
+    dot_dict = DotDict(HEADERS)
+
+    assert benchmark(lambda: [dot_dict.Server for _ in range(100)])
+
+
+def test_rgetattr_result_fields(benchmark, fuzz_result):
+    fields = [
+        "code",
+        "lines",
+        "words",
+        "chars",
+        "md5",
+        "url",
+        "history.headers.response.Server",
+        "history.params.get.lang",
+        "history.cookies.response",
+    ]
+
+    assert len(benchmark(lambda: [rgetattr(fuzz_result, f) for f in fields])) == len(
+        fields
+    )
+
+
+def test_rsetattr_request_field(benchmark, fuzz_result):
+    def run():
+        rsetattr(fuzz_result, "history.params.get.lang", "fr", None)
+        return rgetattr(fuzz_result, "history.params.get.lang")
+
+    assert benchmark(run) == "fr"
+
+
+def test_json_minify(benchmark):
+    assert len(benchmark(lambda: json_minify(JSON_DOCUMENT))) < len(JSON_DOCUMENT)
+
+
+def test_value_in_any_list_item(benchmark):
+    items = ["/dir%d/item%d.html" % (i, i) for i in range(500)]
+
+    assert benchmark(lambda: value_in_any_list_item("item499", items))

--- a/benchmarks/test_bench_iterators.py
+++ b/benchmarks/test_bench_iterators.py
@@ -1,0 +1,51 @@
+"""Benchmarks for the payload combination iterators.
+
+When several payloads are given (-z ... -z ...), an iterator combines them. The
+cost of that combination is paid for every request wfuzz sends.
+"""
+
+from wfuzz.dictionaries import TupleIt
+from wfuzz.plugins.iterators.iterations import chain, product
+from wfuzz.plugins.iterators.iterations import zip as zip_it
+from wfuzz.plugins.payloads.range import range as range_payload
+
+
+def make_payload(spec="0-999"):
+    return range_payload({"default": spec})
+
+
+def test_iterator_zip(benchmark):
+    def run():
+        return list(zip_it(make_payload(), make_payload(), make_payload()))
+
+    assert len(benchmark(run)) == 1000
+
+
+def test_iterator_chain(benchmark):
+    def run():
+        return list(chain(make_payload(), make_payload(), make_payload()))
+
+    assert len(benchmark(run)) == 3000
+
+
+def test_iterator_product(benchmark):
+    def run():
+        return list(product(make_payload("0-99"), make_payload("0-99")))
+
+    assert len(benchmark(run)) == 10000
+
+
+def test_iterator_product_three_payloads(benchmark):
+    def run():
+        return list(
+            product(make_payload("0-19"), make_payload("0-19"), make_payload("0-19"))
+        )
+
+    assert len(benchmark(run)) == 8000
+
+
+def test_iterator_single_payload(benchmark):
+    def run():
+        return list(TupleIt(make_payload("0-4999")))
+
+    assert len(benchmark(run)) == 5000

--- a/benchmarks/test_bench_payloads.py
+++ b/benchmarks/test_bench_payloads.py
@@ -1,0 +1,107 @@
+"""Benchmarks for the payload plugins.
+
+Payloads generate the words that are injected in the fuzzed requests. Iterating
+a full payload is what determines how fast a wordlist can be consumed.
+"""
+
+import pytest
+
+from wfuzz.plugins.payloads.buffer_overflow import buffer_overflow
+from wfuzz.plugins.payloads.file import file as file_payload
+from wfuzz.plugins.payloads.hexrange import hexrange
+from wfuzz.plugins.payloads.list import list as list_payload
+from wfuzz.plugins.payloads.names import names
+from wfuzz.plugins.payloads.permutation import permutation
+from wfuzz.plugins.payloads.range import range as range_payload
+
+
+def drain(payload):
+    return [word.content for word in payload]
+
+
+def test_payload_range(benchmark):
+    words = benchmark(lambda: drain(range_payload({"default": "0-5000"})))
+
+    assert len(words) == 5001
+
+
+def test_payload_hexrange(benchmark):
+    words = benchmark(lambda: drain(hexrange({"default": "0-fff"})))
+
+    assert len(words) == 4096
+
+
+def test_payload_permutation(benchmark):
+    words = benchmark(lambda: drain(permutation({"default": "abcdef0123-3"})))
+
+    assert len(words) == 1000
+
+
+def test_payload_buffer_overflow(benchmark):
+    words = benchmark(lambda: drain(buffer_overflow({"default": "50000"})))
+
+    assert len(words[0]) == 50000
+
+
+def test_payload_list(benchmark, words):
+    spec = "-".join(word.replace("-", "\\-") for word in words)
+
+    generated = benchmark(lambda: drain(list_payload({"default": spec})))
+
+    assert len(generated) == len(words)
+
+
+def test_payload_names(benchmark):
+    generated = benchmark(lambda: drain(names({"default": "john-fitzgerald-smith"})))
+
+    assert len(generated) > 10
+
+
+def test_payload_file(benchmark, common_wordlist_path):
+    """Reads a wordlist from disk, including the encoding auto-detection."""
+
+    def run():
+        payload = file_payload(
+            {"fn": common_wordlist_path, "count": "False", "encoding": "Auto"}
+        )
+        try:
+            return drain(payload)
+        finally:
+            payload.close()
+
+    assert len(benchmark(run)) > 900
+
+
+def test_payload_file_fixed_encoding(benchmark, common_wordlist_path):
+    """Same as above without the chardet based encoding detection."""
+
+    def run():
+        payload = file_payload(
+            {"fn": common_wordlist_path, "count": "False", "encoding": "utf-8"}
+        )
+        try:
+            return drain(payload)
+        finally:
+            payload.close()
+
+    assert len(benchmark(run)) > 900
+
+
+def test_payload_ipnet(benchmark):
+    pytest.importorskip("netaddr")
+    from wfuzz.plugins.payloads.ipnet import ipnet
+
+    generated = benchmark(lambda: drain(ipnet({"default": "192.168.0.0/22"})))
+
+    assert len(generated) == 1022
+
+
+def test_payload_iprange(benchmark):
+    pytest.importorskip("netaddr")
+    from wfuzz.plugins.payloads.iprange import iprange
+
+    generated = benchmark(
+        lambda: drain(iprange({"default": "192.168.0.1-192.168.3.254"}))
+    )
+
+    assert len(generated) == 1022

--- a/benchmarks/test_bench_request.py
+++ b/benchmarks/test_bench_request.py
@@ -1,0 +1,109 @@
+"""Benchmarks for the HTTP request/response objects.
+
+Every fuzzed request is built from a seed request and every response is parsed
+and turned into a FuzzResult, so these paths run once per HTTP request.
+"""
+
+from wfuzz.fuzzobjects import FuzzResult
+from wfuzz.fuzzrequest import FuzzRequest
+from wfuzz.plugin_api.urlutils import parse_url
+
+from conftest import make_fuzz_result
+
+URL = "http://www.wfuzz.org/admin/login.php?id=1&lang=en&redirect=%2Fhome"
+
+
+def test_parse_raw_request(benchmark, raw_request):
+    def run():
+        request = FuzzRequest()
+        request.update_from_raw_http(raw_request, "http")
+        return request
+
+    assert benchmark(run).url == URL
+
+
+def test_parse_raw_post_request(benchmark, raw_post_request):
+    def run():
+        request = FuzzRequest()
+        request.update_from_raw_http(raw_post_request, "http")
+        return request
+
+    assert benchmark(run).params.post["user"] == "admin"
+
+
+def test_parse_raw_request_and_response(
+    benchmark, raw_request, raw_response, html_page
+):
+    content = html_page.encode("utf-8")
+
+    def run():
+        request = FuzzRequest()
+        request.update_from_raw_http(raw_request, "http", raw_response, content)
+        return request
+
+    assert benchmark(run).code == 200
+
+
+def test_build_request_from_url(benchmark):
+    def run():
+        request = FuzzRequest()
+        request.url = URL
+        request.headers.request = {
+            "User-Agent": "Wfuzz/3.1.0",
+            "Accept": "*/*",
+            "Cookie": "session=39ad7bcb9a0f4c0b",
+        }
+        request.params.post = "user=admin&password=admin"
+        return request
+
+    assert benchmark(run).method == "POST"
+
+
+def test_request_to_cache_key(benchmark, fuzz_result):
+    history = fuzz_result.history
+
+    assert "login.php" in benchmark(history.to_cache_key)
+
+
+def test_request_params_access(benchmark, fuzz_result):
+    history = fuzz_result.history
+
+    def run():
+        return (
+            dict(history.params.get),
+            dict(history.headers.request),
+            dict(history.headers.response),
+            dict(history.cookies.response),
+        )
+
+    assert benchmark(run)[0]["lang"] == "en"
+
+
+def test_fuzz_result_update(benchmark, raw_request, html_page):
+    """md5, chars, words and lines computation over the response body."""
+    result = make_fuzz_result(raw_request, html_page)
+
+    assert benchmark(result.update).words > 1000
+
+
+def test_fuzz_result_from_history(benchmark, raw_request, raw_response, html_page):
+    content = html_page.encode("utf-8")
+    request = FuzzRequest()
+    request.update_from_raw_http(raw_request, "http", raw_response, content)
+
+    def run():
+        return FuzzResult(history=request, track_id=False)
+
+    assert benchmark(run).code == 200
+
+
+def test_fuzz_result_str(benchmark, fuzz_result):
+    assert "C=200" in benchmark(lambda: str(fuzz_result))
+
+
+def test_parse_url(benchmark):
+    urls = ["%s&index=%d" % (URL, index) for index in range(200)]
+
+    parsed = benchmark(lambda: [parse_url(url) for url in urls])
+
+    assert len(parsed) == len(urls)

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,7 @@ dev_requires = [
 
 install_requires = [
     'pycurl',
-    'pyparsing<2.4.2;python_version<="3.4"',
-    'pyparsing>=2.4.2;python_version>="3.5"',
-    'six',
-    'configparser;python_version<"3.5"',
+    'pyparsing>=2.4.2',
     'chardet',
 ]
 
@@ -79,12 +76,11 @@ try:
             'Natural Language :: English',
             'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
+'Programming Language :: Python :: 3.9',
+'Programming Language :: Python :: 3.10',
+'Programming Language :: Python :: 3.11',
+'Programming Language :: Python :: 3.12',
+'Programming Language :: Python :: 3.13',
         ),
     )
 finally:

--- a/src/wfuzz/externals/moduleman/loader.py
+++ b/src/wfuzz/externals/moduleman/loader.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-import imp
+import importlib.util
 import os.path
 
 
@@ -58,8 +58,9 @@ class FileLoader(IModuleLoader):
         module = None
 
         try:
-            exten_file, filename, description = imp.find_module(fn, [dirname])
-            module = imp.load_module(fn, exten_file, filename, description)
+            spec = importlib.util.spec_from_file_location(fn, os.path.join(dirname, fn + ".py"))
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
         except ImportError as msg:
             self.__logger.critical(
                 "__load_py_from_file. Filename: %s Exception, msg=%s" % (filename, msg)

--- a/src/wfuzz/externals/reqresp/Response.py
+++ b/src/wfuzz/externals/reqresp/Response.py
@@ -1,5 +1,5 @@
 import re
-import cgi
+from email.message import Message
 
 from io import BytesIO
 import gzip
@@ -22,7 +22,10 @@ def get_encoding_from_headers(headers):
     if not content_type:
         return None
 
-    content_type, params = cgi.parse_header(content_type)
+    m = Message()
+    m["content-type"] = content_type
+    content_type = m.get_content_type()
+    params = dict(m.get_params() or [])
 
     if "charset" in params:
         return params["charset"].strip("'\"")

--- a/src/wfuzz/helpers/file_func.py
+++ b/src/wfuzz/helpers/file_func.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import re
-import pkg_resources
+import importlib.resources
 
 from chardet.universaldetector import UniversalDetector
 import chardet
@@ -15,7 +15,7 @@ def get_filter_help_file():
 
     filter_help_text = None
     try:
-        fname = pkg_resources.resource_filename("wfuzz", FILTER_HELP_FILE)
+        fname = str(importlib.resources.files("wfuzz").joinpath(FILTER_HELP_FILE))
         filter_help_text = open(fname).read()
     except IOError:
         filter_help_text = open(get_path(FILTER_HELP_DEV_FILE)).read()

--- a/src/wfuzz/helpers/str_func.py
+++ b/src/wfuzz/helpers/str_func.py
@@ -1,6 +1,6 @@
 import re
 import sys
-import six
+
 
 
 from .obj_dic import DotDict
@@ -85,7 +85,7 @@ def convert_to_unicode(text):
         }
     elif isinstance(text, list):
         return [convert_to_unicode(element) for element in text]
-    elif isinstance(text, six.string_types):
+    elif isinstance(text, str):
         return text.encode("utf-8", errors="ignore")
     else:
         return text

--- a/src/wfuzz/ui/console/output.py
+++ b/src/wfuzz/ui/console/output.py
@@ -7,7 +7,7 @@ import operator
 from functools import reduce
 
 # Python 2 and 3: zip_longest
-from six import StringIO
+from io import StringIO
 
 try:
     from itertools import zip_longest


### PR DESCRIPTION
## Problem

`src/wfuzz/helpers/file_func.py` imports `pkg_resources` which is 
deprecated and scheduled for removal in setuptools >= 81, causing 
a `UserWarning` on every wfuzz invocation and a future 
`ModuleNotFoundError`.

Fixes #381.

## Fix

Replace `pkg_resources.resource_filename()` with 
`importlib.resources.files()` from the Python stdlib (available 
since Python 3.9):

```python
# Before
fname = pkg_resources.resource_filename("wfuzz", FILTER_HELP_FILE)

# After
fname = str(importlib.resources.files("wfuzz").joinpath(FILTER_HELP_FILE))
```

## Testing

Tested locally on Python 3.12.1:

python3 -c "from wfuzz.helpers.file_func import get_filter_help_file; print(get_filter_help_file()[:100])"

Output: `Advanced Usage...` ✅ No warnings, no errors.

## Notes

This approach is preferred over `pkgutil.get_data()` (used in the 
draft PR #382) as it returns a path string directly compatible with 
`open()`, without needing to decode bytes.